### PR TITLE
Update service gateway to yobi

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Production top page for `chumu.net`.
 
-This GitHub Pages site is the front door for chumu, Musashi, future services, and official account links.
+This GitHub Pages site is the front door for chumu, yobi, future services, and official account links.
 
 ## Structure
 

--- a/index.html
+++ b/index.html
@@ -10,12 +10,12 @@
     </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="chumu.net is the personal hub for chumu, Musashi, future services, and official account links.">
+    <meta name="description" content="chumu.net is the personal hub for chumu, yobi, future services, and official account links.">
     <meta name="theme-color" content="#9be233">
     <meta name="color-scheme" content="dark light">
     <meta property="og:site_name" content="chumu.net">
     <meta property="og:title" content="chumu.net">
-    <meta property="og:description" content="Personal hub for chumu, Musashi, future services, and official account links.">
+    <meta property="og:description" content="Personal hub for chumu, yobi, future services, and official account links.">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://chumu.net/">
     <meta property="og:image" content="https://chumu.net/images/og-image.jpg">
@@ -23,7 +23,7 @@
     <meta property="og:image:height" content="630">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="chumu.net">
-    <meta name="twitter:description" content="Personal hub for chumu, Musashi, future services, and official account links.">
+    <meta name="twitter:description" content="Personal hub for chumu, yobi, future services, and official account links.">
     <meta name="twitter:image" content="https://chumu.net/images/og-image.jpg">
     <title>chumu.net</title>
     <link rel="icon" href="favicon.svg" type="image/svg+xml">
@@ -51,16 +51,16 @@
                 <p class="eyebrow">Personal hub / Service gateway</p>
                 <h1 id="hero-title">chumu</h1>
                 <p class="hero-copy">
-                    A clean entry point for Musashi, future services, and the official places to find chumu online.
+                    A clean entry point for yobi, future services, and the official places to find chumu online.
                 </p>
                 <div class="hero-actions">
-                    <a class="button primary" href="#services">View Musashi</a>
+                    <a class="button primary" href="https://yobi.chumu.net/" target="_blank" rel="noopener noreferrer">Open yobi</a>
                     <a class="button ghost" href="#connect">Find accounts</a>
                 </div>
             </div>
             <div class="signal-strip" aria-label="Site highlights">
                 <span>chumu.net</span>
-                <span>Musashi</span>
+                <span>yobi</span>
                 <span>Services</span>
                 <span>Official links</span>
             </div>
@@ -85,7 +85,7 @@
                 <article class="profile-card">
                     <p class="label">Base</p>
                     <h3>chumu.net</h3>
-                    <p>The front door for Musashi now, and the place future services can connect later.</p>
+                    <p>The front door for yobi now, and the place future services can connect later.</p>
                 </article>
             </div>
         </section>
@@ -93,14 +93,14 @@
         <section id="services" class="services-section" aria-labelledby="services-title">
             <div class="section-heading">
                 <p class="eyebrow">Services</p>
-                <h2 id="services-title">From Musashi to what comes next.</h2>
+                <h2 id="services-title">From yobi to what comes next.</h2>
             </div>
             <div class="service-grid" id="service-list" aria-live="polite">
                 <article class="service-card featured">
                     <p class="label">Featured</p>
-                    <h3>Musashi</h3>
-                    <p>The first service connected from chumu.net. Its public destination can be added when ready.</p>
-                    <span class="text-link disabled">Coming soon</span>
+                    <h3>yobi</h3>
+                    <p>A yobi.chumu.net service for viewing past questions from the Japanese preliminary bar examination.</p>
+                    <a class="text-link" href="https://yobi.chumu.net/" target="_blank" rel="noopener noreferrer">Open yobi</a>
                 </article>
                 <article class="service-card muted">
                     <p class="label">Next</p>
@@ -139,7 +139,7 @@
 
     <footer class="site-footer">
         <span>chumu.net</span>
-        <span>Fresh gateway for Musashi and future services.</span>
+        <span>Fresh gateway for yobi and future services.</span>
     </footer>
 
     <script src="script.js"></script>

--- a/links.json
+++ b/links.json
@@ -1,12 +1,12 @@
 {
   "services": [
     {
-      "id": "musashi",
-      "name": "Musashi",
+      "id": "yobi",
+      "name": "yobi",
       "status": "Featured",
-      "description": "Main service connected from chumu.net. Add the public URL when it is ready.",
-      "url": "",
-      "linkLabel": "Open Musashi"
+      "description": "A yobi.chumu.net service for viewing past questions from the Japanese preliminary bar examination.",
+      "url": "https://yobi.chumu.net/",
+      "linkLabel": "Open yobi"
     }
   ],
   "accounts": {

--- a/script.js
+++ b/script.js
@@ -1,12 +1,12 @@
 const fallbackLinks = {
     services: [
         {
-            id: "musashi",
-            name: "Musashi",
+            id: "yobi",
+            name: "yobi",
             status: "Featured",
-            description: "The first service connected from chumu.net. Its public destination can be added when ready.",
-            url: "",
-            linkLabel: "Open Musashi"
+            description: "A yobi.chumu.net service for viewing past questions from the Japanese preliminary bar examination.",
+            url: "https://yobi.chumu.net/",
+            linkLabel: "Open yobi"
         }
     ],
     accounts: {


### PR DESCRIPTION
## Summary
- Rename the featured service from Musashi to yobi across the public page and link data
- Point the service CTA to https://yobi.chumu.net/
- Update fallback data and README wording to match

## Checks
- node --check script.js
- Parsed links.json with ConvertFrom-Json
- Verified local HTTP page includes yobi URL and no Musashi text
- Confirmed https://yobi.chumu.net/ returns 200 and resolves to /login